### PR TITLE
Fix repeating messages

### DIFF
--- a/webhook.js
+++ b/webhook.js
@@ -82,12 +82,9 @@ function receivedMessage(event) {
   const recipientID = event.recipient.id;
   const timeOfMessage = event.timestamp;
   const message = event.message;
-  if (event.message.quick_reply) {
-    const quickReply = event.message.quick_reply.payload;
-  }
 
-  console.log('Received message for user %d and page %d at %d with message:',
-      senderID, recipientID, timeOfMessage, quickReply.payload);
+  console.log('Received message for user %d and page %d at %d with message: %d',
+      senderID, recipientID, timeOfMessage, message);
     // console.log(JSON.stringify(message));
 
   const messageId = message.mid;

--- a/webhook.js
+++ b/webhook.js
@@ -82,9 +82,10 @@ function receivedMessage(event) {
   const recipientID = event.recipient.id;
   const timeOfMessage = event.timestamp;
   const message = event.message;
+  const quickReply = event.message.quick_reply.payload;
 
   console.log('Received message for user %d and page %d at %d with message:',
-      senderID, recipientID, timeOfMessage);
+      senderID, recipientID, timeOfMessage, quickReply);
     // console.log(JSON.stringify(message));
 
   const messageId = message.mid;

--- a/webhook.js
+++ b/webhook.js
@@ -82,10 +82,12 @@ function receivedMessage(event) {
   const recipientID = event.recipient.id;
   const timeOfMessage = event.timestamp;
   const message = event.message;
-  const quickReply = event.message.quick_reply.payload;
+  if (event.message.quick_reply) {
+    const quickReply = event.message.quick_reply.payload;
+  }
 
   console.log('Received message for user %d and page %d at %d with message:',
-      senderID, recipientID, timeOfMessage, quickReply);
+      senderID, recipientID, timeOfMessage, quickReply.payload);
     // console.log(JSON.stringify(message));
 
   const messageId = message.mid;

--- a/webhook.js
+++ b/webhook.js
@@ -83,9 +83,9 @@ function receivedMessage(event) {
   const timeOfMessage = event.timestamp;
   const message = event.message;
 
-  console.log('Received message for user %d and page %d at %d with message: %d',
-      senderID, recipientID, timeOfMessage, message.quick_reply);
-    // console.log(JSON.stringify(message));
+  console.log('Received message for user %d and page %d at %d with message:',
+      senderID, recipientID, timeOfMessage);
+  console.log(JSON.stringify(message));
 
   const messageId = message.mid;
 

--- a/webhook.js
+++ b/webhook.js
@@ -84,7 +84,7 @@ function receivedMessage(event) {
   const message = event.message;
 
   console.log('Received message for user %d and page %d at %d with message: %d',
-      senderID, recipientID, timeOfMessage, message);
+      senderID, recipientID, timeOfMessage, message.quick_reply);
     // console.log(JSON.stringify(message));
 
   const messageId = message.mid;

--- a/webhook.js
+++ b/webhook.js
@@ -55,6 +55,9 @@ app.post('/webhook', (req, res) => {
             },
             message: {
               text: 'Hey [name], I\'m your personal assistant in the run up to the General Elections! Type your postcode or send me your location to get started .',
+              quick_replies: [
+              { content_type: 'location' },
+              ],
             },
           };
           callSendAPI(messageData);
@@ -63,6 +66,7 @@ app.post('/webhook', (req, res) => {
         }
       });
     });
+
 
     // Assume all went well.
     //

--- a/webhook.js
+++ b/webhook.js
@@ -45,25 +45,20 @@ app.post('/webhook', (req, res) => {
 
       // Iterate over each messaging event
       entry.messaging.forEach((event) => {
-        if (event.postback && event.postback.payload === 'FACEBOOK_WELCOME') {
-
-
-        var messageData = {
-          recipient: {
-            id: event.sender.id,
-          },
-          message: {
-            text: 'Hey [name], I\'m your personal assistant in the run up to the General Elections! Type your postcode or send me your location to get started .',
-          },
-          }
-          callSendAPI(messageData);
-
-        }
-        else if (event.message) {
-          console.log('inside event.message if statement')
+        if (event.message) {
+          console.log('inside event.message if statement');
           receivedMessage(event);
-        }
-         else {
+        } else if (event.postback && event.postback.payload === 'FACEBOOK_WELCOME') {
+          const messageData = {
+            recipient: {
+              id: event.sender.id,
+            },
+            message: {
+              text: 'Hey [name], I\'m your personal assistant in the run up to the General Elections! Type your postcode or send me your location to get started .',
+            },
+          };
+          callSendAPI(messageData);
+        } else {
           console.log('Webhook received unknown event: ', event);
         }
       });
@@ -99,7 +94,7 @@ function receivedMessage(event) {
     });
 
     apiai_request.on('response', (response) => {
-      let responseText = response.result.fulfillment.speech;
+      const responseText = response.result.fulfillment.speech;
         // console.log('response is ', response);
       console.log('responseText is ', responseText);
       sendTextMessage(senderID, responseText);


### PR DESCRIPTION
Messages now appear in the right order and don't repeat.

The location button now appears and we get this back if we stringify the message object:

`{"mid":"mid.$cAACVbcqAv_NiBdGE4Vb1Iw7jHE0k","seq":134094,"attachments":[{"title":"Philippa's Location","url":"https://l.facebook.com/l.php?u=https%3A%2F%2Fwww.bing.com%2Fmaps%2Fdefault.aspx%3Fv%3D2%26pc%3DFACEBK%26mid%3D8100%26where1%3D51.529487%252C%2B-0.0423492%26FORM%3DFBKPL1%26mkt%3Den-US&h=ATPxu2eGlhkGKN7JvEQd1uCytjsk51-1aNqgfcnYK8i4YKYjQAVeZDuOoWBy_3UR4Sk5tlRFPxRIXC_b-E4ZiJtesVdkFpAhJKX3SF3Hx9Nn&s=1&enc=AZPAtqERgyPy0EE4XaJe9MV09jtmognjLxPBdLfvQo9W4_mciUnWbnkNBNDwtY-bRbgy03K5tMSkqYwyjq9LGdP2","type":"location","payload":{"coordinates":{"lat":51.529487,"long":-0.0423492}}}]}`

fixes #44 relates to #46 